### PR TITLE
La til kildehenvisning i Readme og som kommentar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,12 @@ Under prosjektet vårt har vi brukt Git for å holde oversikt over alle endringe
 
 NB. Dataen vi har benyttet oss av er hentet fra Met.no og deres API "Frost". Dette er brukt for skolearbeid. 
 
+## Kilder 
 
+- Rouhani, M. (u.å.). *Introduksjon til datavitenskap (TDT4114)*. Hentet fra https://rouhani.folk.ntnu.no/textbooks/tdt4114/intro.html
+
+- Met.no. (u.å.). *Python-eksempel for Frost API*. Hentet fra https://frost.met.no/python_example.html
+
+    
+
+ 

--- a/notebooks/HenteData.ipynb
+++ b/notebooks/HenteData.ipynb
@@ -18,6 +18,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Kildehenvisning\n",
+    "Denne notebooken benytter eksempler og metoder fra Met.no Frost API Python-eksempel: \n",
+    "https://frost.met.no/python_example.html \n",
+    "\n",
+    "Koden er tilpasset vårt prosjekt for å hente data. \n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -24,3 +24,9 @@ Notebooksene bruker funksjoner/metoder fra `src/` og lagrer data i mappen `data/
     Kodecellene fungerer i hovedsak på den måten at de henter definerte metoder/funksjoner, og bruker de for å hente, rense, visualisere og utføre analyser. 
     Markdowncellene fungerer som et supplement, hvor de både forklarer teori, og hvilke metoder som er benyttet. Samt at de kommenterer resultatene vi finner. 
     Vi har ved hjelp av markdown celler kommentert vurderingskriteriene utifra hva vi har gjort.
+
+
+## Kilder 
+- Met.no. (u.å.). *Python-eksempel for Frost API*. Hentet fra https://frost.met.no/python_example.html
+  Brukt som utgangspunkt for datahenting i `hente_data.ipynb` og `hente_data.py`. 
+ 

--- a/src/hente_data.py
+++ b/src/hente_data.py
@@ -1,6 +1,7 @@
 import requests
 import time
-
+# Kilde:
+# Met.no. (u.å.). *Python-eksempel for Frost API*. Hentet fra https://frost.met.no/python_example.html
 def hent_data_fra_frost(endpoint, params, client_id, maks_forsøk=3, ventetid=2):
     """
     Henter data fra Frost API med støtte for flere forsøk og feilhåndtering.


### PR DESCRIPTION
La til kildehenvisning om hvordan vi klarte å kjøre API-kall. Det fikk vi fra met.no sin egen side, som er der vi henter data fra. 
I tillegg er også pensumboken lagt inn som kilde i README, da denne har vært til stor hjelp gjennom prosjektet. 